### PR TITLE
update collection serializer - remove redundant key

### DIFF
--- a/lib/oat/adapters/json_api.rb
+++ b/lib/oat/adapters/json_api.rb
@@ -130,9 +130,9 @@ module Oat
         else
           h = {data: {}}
           if @treat_as_resource_collection
-            h[:data][root_name] = data[:resource_collection]
+            h[:data] = data[:resource_collection]
           else
-            h[:data]= data
+            h[:data] = data
           end
           h[:linked] = @entities if @entities.keys.any?
           h[:links] = @link_templates if @link_templates.keys.any?

--- a/spec/adapters/json_api_spec.rb
+++ b/spec/adapters/json_api_spec.rb
@@ -284,7 +284,7 @@ describe Oat::Adapters::JsonAPI do
       let(:collection_hash) { collection_serializer.to_hash }
 
       context 'top level' do
-        subject(:users){ collection_hash.fetch(:data).fetch(:users) }
+        subject(:users){ collection_hash.fetch(:data) }
         its(:size) { should eq(2) }
 
         it 'contains the correct first user properties' do


### PR DESCRIPTION
According to [jsonapi specification](http://jsonapi.org/format/#document-structure-top-level) Primary data MUST be either a single resource object, **an array** of resource objects, or a value representing a resource relationship.

This PR removes redundant key from the json structure.
BEFORE:

``` json
{ 
  "data": {
    "articles": [{ 
      "type": "articles", 
      "id": "1", 
      "title": "JSON API paints my bikeshed!"
    }]
  } 
}
```

AFTER:

``` json
{ 
  "data": [{ 
    "type": "articles", 
    "id": "1", 
    "title": "JSON API paints my bikeshed!"
  }] 
}
```
